### PR TITLE
fix: disable SSAO for transparent surfaces.

### DIFF
--- a/Runtime/Shaders/SRPBatchingHelper.cs
+++ b/Runtime/Shaders/SRPBatchingHelper.cs
@@ -35,7 +35,7 @@ namespace DCL.Helpers
                 if (zWrite == 0)
                 {
                     material.SetInt("_Surface", 1);
-                    material.DisableKeyword("_SCREEN_SPACE_OCCLUSION");
+                    material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
                     material.SetShaderPassEnabled("DepthNormals", false);
                     material.renderQueue = (int) UnityEngine.Rendering.RenderQueue.Transparent;
                     OnMaterialProcess?.Invoke(material);
@@ -55,7 +55,10 @@ namespace DCL.Helpers
             int baseQueue;
 
             if (material.renderQueue == (int) UnityEngine.Rendering.RenderQueue.AlphaTest)
+            {
+                material.EnableKeyword("_SURFACE_TYPE_TRANSPARENT");
                 baseQueue = (int) UnityEngine.Rendering.RenderQueue.Geometry + 600;
+            }
             else
                 baseQueue = (int) UnityEngine.Rendering.RenderQueue.Geometry;
 

--- a/Runtime/Shaders/URP/Lighting.hlsl
+++ b/Runtime/Shaders/URP/Lighting.hlsl
@@ -476,7 +476,11 @@ struct AmbientOcclusionFactor
 
 half SampleAmbientOcclusion(float2 normalizedScreenSpaceUV)
 {
-    if (_Surface == SURFACE_TRANSPARENT)
+    #if defined(_SURFACE_TYPE_TRANSPARENT)
+        return 1;
+    #endif
+
+    if (_Surface == SURFACE_TRANSPARENT )
         return 1;
         
     float2 uv = UnityStereoTransformScreenSpaceTex(normalizedScreenSpaceUV);
@@ -834,9 +838,11 @@ half4 UniversalFragmentPBR(InputData inputData, SurfaceData surfaceData)
     Light mainLight = GetMainLight(inputData.shadowCoord, inputData.positionWS, shadowMask);
 
     #if defined(_SCREEN_SPACE_OCCLUSION)
+    #if !defined(_SURFACE_TYPE_TRANSPARENT)
         AmbientOcclusionFactor aoFactor = GetScreenSpaceAmbientOcclusion(inputData.normalizedScreenSpaceUV);
         mainLight.color *= aoFactor.directAmbientOcclusion;
         surfaceData.occlusion = min(surfaceData.occlusion, aoFactor.indirectAmbientOcclusion);
+    #endif
     #endif
 
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI);
@@ -854,7 +860,9 @@ half4 UniversalFragmentPBR(InputData inputData, SurfaceData surfaceData)
     {
         Light light = GetAdditionalLight(lightIndex, inputData.positionWS, shadowMask);
         #if defined(_SCREEN_SPACE_OCCLUSION)
+        #if !defined(_SURFACE_TYPE_TRANSPARENT)
             light.color *= aoFactor.directAmbientOcclusion;
+        #endif
         #endif
         color += LightingPhysicallyBased(brdfData, brdfDataClearCoat,
                                          light,
@@ -902,9 +910,11 @@ half4 UniversalFragmentBlinnPhong(InputData inputData, half3 diffuse, half4 spec
     Light mainLight = GetMainLight(inputData.shadowCoord, inputData.positionWS, shadowMask);
 
     #if defined(_SCREEN_SPACE_OCCLUSION)
+    #if !defined(_SURFACE_TYPE_TRANSPARENT)
         AmbientOcclusionFactor aoFactor = GetScreenSpaceAmbientOcclusion(inputData.normalizedScreenSpaceUV);
         mainLight.color *= aoFactor.directAmbientOcclusion;
         inputData.bakedGI *= aoFactor.indirectAmbientOcclusion;
+    #endif
     #endif
 
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI);
@@ -919,7 +929,9 @@ half4 UniversalFragmentBlinnPhong(InputData inputData, half3 diffuse, half4 spec
     {
         Light light = GetAdditionalLight(lightIndex, inputData.positionWS, shadowMask);
         #if defined(_SCREEN_SPACE_OCCLUSION)
+        #if !defined(_SURFACE_TYPE_TRANSPARENT)
             light.color *= aoFactor.directAmbientOcclusion;
+        #endif
         #endif
         half3 attenuatedLightColor = light.color * (light.distanceAttenuation * light.shadowAttenuation);
         diffuseColor += LightingLambert(attenuatedLightColor, light.direction, inputData.normalWS);

--- a/Runtime/Shaders/URP/LitInput.hlsl
+++ b/Runtime/Shaders/URP/LitInput.hlsl
@@ -131,6 +131,10 @@ half4 SampleMetallicSpecGloss(float2 uv, half albedoAlpha)
 
 half SampleOcclusion(float2 uv)
 {
+    #if defined(_SURFACE_TYPE_TRANSPARENT)
+        return 1.0;
+    #endif
+
     // No occlusion for transparent surfaces. They don't render normals.
     if (_Surface == SURFACE_TRANSPARENT)
         return 1.0;


### PR DESCRIPTION
Now transparent objects are ignoring properly SSAO.