### PR TITLE
fix: sceneshader metallicroughness fix

### DIFF
--- a/Runtime/Shaders/SceneRendering/Scene_Input.hlsl
+++ b/Runtime/Shaders/SceneRendering/Scene_Input.hlsl
@@ -43,7 +43,7 @@ TEXTURE2D(_MetallicGlossMap);   SAMPLER(sampler_MetallicGlossMap);
 
 half4 SampleMetallicSpecGloss(float2 uv, half albedoAlpha)
 {
-    half4 specGloss = half4(0.0, 0.0, 0.0, 0.0); //half4(SAMPLE_METALLICSPECULAR(uv));
+    half4 specGloss = half4(SAMPLE_METALLICSPECULAR(uv));
     #ifdef _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
         specGloss.a = albedoAlpha * _Smoothness;
     #else


### PR DESCRIPTION
Fixes the missing metallic capability

To test: load any asset with material using scene shader and containing metallic values