### PR TITLE
fix: remove incorrect asset bundle assignation

### DIFF
--- a/Runtime/Shaders/SceneRendering.meta
+++ b/Runtime/Shaders/SceneRendering.meta
@@ -4,5 +4,5 @@ folderAsset: yes
 DefaultImporter:
   externalObjects: {}
   userData: 
-  assetBundleName: scenerendering
+  assetBundleName: 
   assetBundleVariant: 

--- a/Runtime/Shaders/SceneRendering/SceneVariants.shadervariants.meta
+++ b/Runtime/Shaders/SceneRendering/SceneVariants.shadervariants.meta
@@ -4,5 +4,5 @@ NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0
   userData: 
-  assetBundleName: dcl/scene_ignore_windows
+  assetBundleName: 
   assetBundleVariant: 

--- a/Runtime/Shaders/SceneRendering/TexArray/Scene_TexArray.shader.meta
+++ b/Runtime/Shaders/SceneRendering/TexArray/Scene_TexArray.shader.meta
@@ -5,5 +5,5 @@ ShaderImporter:
   defaultTextures: []
   nonModifiableTextures: []
   userData: 
-  assetBundleName: dcl/scene_texarray_ignore_windows
+  assetBundleName: 
   assetBundleVariant: 

--- a/Runtime/Shaders/SceneRendering/TexArray/Scene_TexArrayVariants.shadervariants.meta
+++ b/Runtime/Shaders/SceneRendering/TexArray/Scene_TexArrayVariants.shadervariants.meta
@@ -4,5 +4,5 @@ NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0
   userData: 
-  assetBundleName: dcl/scene_texarray_ignore_windows
+  assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Removes pending ab assignations. This will incorrectly build asset bundles in the CI