### PR TITLE
Feat: Adding support for Alpha textures in the scene shaders (#1691)

### DIFF
--- a/Runtime/Shaders/SceneRendering/Scene.shader
+++ b/Runtime/Shaders/SceneRendering/Scene.shader
@@ -7,7 +7,8 @@ Shader "DCL/Scene"
 
         [MainTexture] _BaseMap("Albedo", 2D) = "white" {}
         [MainColor] _BaseColor("Color", Color) = (1,1,1,1)
-
+        _AlphaTexture("Alpha Texture", 2D) = "white" {}
+        
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
 
         _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5

--- a/Runtime/Shaders/SceneRendering/Scene_Input.hlsl
+++ b/Runtime/Shaders/SceneRendering/Scene_Input.hlsl
@@ -9,6 +9,7 @@
 
 UNITY_INSTANCING_BUFFER_START(UnityPerMaterial)
 UNITY_DEFINE_INSTANCED_PROP(float4, _BaseMap_ST)
+UNITY_DEFINE_INSTANCED_PROP(float4, _AlphaTexture_ST)
 UNITY_DEFINE_INSTANCED_PROP(half4, _BaseColor)
 UNITY_DEFINE_INSTANCED_PROP(half4, _SpecColor)
 UNITY_DEFINE_INSTANCED_PROP(half4, _EmissionColor)
@@ -24,6 +25,7 @@ UNITY_DEFINE_INSTANCED_PROP(float4, _VerticalClipping)
 UNITY_INSTANCING_BUFFER_END(UnityPerMaterial)
 
 #define _BaseMap_ST             UNITY_ACCESS_INSTANCED_PROP(UnityPerMaterial, _BaseMap_ST)
+#define _AlphaTexture_ST        UNITY_ACCESS_INSTANCED_PROP(UnityPerMaterial, _AlphaTexture_ST)
 #define _BaseColor              UNITY_ACCESS_INSTANCED_PROP(UnityPerMaterial, _BaseColor)
 #define _SpecColor              UNITY_ACCESS_INSTANCED_PROP(UnityPerMaterial, _SpecColor)
 #define _EmissionColor          UNITY_ACCESS_INSTANCED_PROP(UnityPerMaterial, _EmissionColor)
@@ -78,7 +80,9 @@ void ApplyPerPixelDisplacement(half3 viewDirTS, inout float2 uv)
 inline void InitializeStandardLitSurfaceData_Scene(float2 uv, out SurfaceData_Scene outSurfaceData)
 {
     half4 albedoAlpha = SampleAlbedoAlpha(uv, TEXTURE2D_ARGS(_BaseMap, sampler_BaseMap));
-    outSurfaceData.alpha = Alpha(albedoAlpha.a, _BaseColor, _Cutoff);
+    half4 alphaTexture = SampleAlbedoAlpha(uv, TEXTURE2D_ARGS(_AlphaTexture, sampler_AlphaTexture));
+
+    outSurfaceData.alpha = Alpha(albedoAlpha.a, _BaseColor, _Cutoff) * saturate(length(alphaTexture.rgb));
     outSurfaceData.albedo = AlphaModulate(albedoAlpha.rgb * _BaseColor.rgb, outSurfaceData.alpha);
 
     half4 specGloss = SampleMetallicSpecGloss(uv, albedoAlpha.a);

--- a/Runtime/Shaders/SceneRendering/Scene_SurfaceInput.hlsl
+++ b/Runtime/Shaders/SceneRendering/Scene_SurfaceInput.hlsl
@@ -8,6 +8,8 @@
 
 TEXTURE2D(_BaseMap);
 SAMPLER(sampler_BaseMap);
+TEXTURE2D(_AlphaTexture);
+SAMPLER(sampler_AlphaTexture);
 float4 _BaseMap_TexelSize;
 float4 _BaseMap_MipInfo;
 TEXTURE2D(_BumpMap);


### PR DESCRIPTION
Now it is allowed to provide an alpha texture to the material, as it was in the old renderer. The final alpha channel is multiplied by the values of the texture.

This need was identified after this bug was reported:
https://github.com/decentraland/unity-explorer/issues/1691