### PR TITLE
Add support for setting the blend op and preserving max alpha

### DIFF
--- a/Runtime/Shaders/SceneRendering/Scene.shader
+++ b/Runtime/Shaders/SceneRendering/Scene.shader
@@ -45,6 +45,8 @@ Shader "DCL/Scene"
         [HideInInspector] _DstBlend("__dst", Float) = 0.0
         [HideInInspector] _SrcBlendAlpha("__srcA", Float) = 1.0
         [HideInInspector] _DstBlendAlpha("__dstA", Float) = 0.0
+        [HideInInspector] _BlendOp("__blendOp", Float) = 0.0
+        [HideInInspector] _BlendOpAlpha("__blendOpA", Float) = 0.0
         [HideInInspector] _ZWrite("__zw", Float) = 1.0
         [HideInInspector] _BlendModePreserveSpecular("_BlendModePreserveSpecular", Float) = 1.0
         [HideInInspector] _AlphaToMask("__alphaToMask", Float) = 0.0
@@ -90,6 +92,7 @@ Shader "DCL/Scene"
             // -------------------------------------
             // Render State Commands
             Blend[_SrcBlend][_DstBlend], [_SrcBlendAlpha][_DstBlendAlpha]
+            BlendOp [_BlendOp], [_BlendOpAlpha]
             ZWrite[_ZWrite]
             Cull[_Cull]
             AlphaToMask[_AlphaToMask]

--- a/Runtime/Shaders/ShaderUtils.cs
+++ b/Runtime/Shaders/ShaderUtils.cs
@@ -106,6 +106,10 @@ namespace DCL.Shaders
 
         public static readonly int SrcBlend = Shader.PropertyToID("_SrcBlend");
         public static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
+        public static readonly int SrcBlendAlpha = Shader.PropertyToID("_SrcBlendAlpha");
+        public static readonly int DstBlendAlpha = Shader.PropertyToID("_DstBlendAlpha");
+        public static readonly int BlendOp = Shader.PropertyToID("_BlendOp");
+        public static readonly int BlendOpAlpha = Shader.PropertyToID("_BlendOpAlpha");
         public static readonly int ZWrite = Shader.PropertyToID("_ZWrite");
         public static readonly int AlphaClip = Shader.PropertyToID("_AlphaClip");
         public static readonly int Cull = Shader.PropertyToID("_Cull");


### PR DESCRIPTION
Adds support for setting the BlendOp operation to the shader and MaterialGenerator (needed by the preview renderer so we preserve the Alpha channel).