### PR TITLE
fix: SceneTexArray rebuilding setup

### DIFF
--- a/Runtime/Shaders/SceneRendering/TexArray/Scene_TexArray.shader
+++ b/Runtime/Shaders/SceneRendering/TexArray/Scene_TexArray.shader
@@ -98,7 +98,7 @@ Shader "DCL/Scene_TexArray"
             AlphaToMask[_AlphaToMask]
 
             HLSLPROGRAM
-            #pragma exclude_renderers gles gles3 glcore
+			//#pragma enable_d3d11_debug_symbols
             #pragma target 4.5
             #pragma require 2darray
 
@@ -135,10 +135,11 @@ Shader "DCL/Scene_TexArray"
             #pragma multi_compile_fragment _ _SHADOWS_SOFT
             #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
             //#pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
-            #pragma multi_compile_fragment _ _LIGHT_LAYERS
+            #pragma multi_compile _ _LIGHT_LAYERS
             #pragma multi_compile_fragment _ _LIGHT_COOKIES
             #pragma multi_compile _ _FORWARD_PLUS
-            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            //#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
 
 
             // -------------------------------------
@@ -151,12 +152,13 @@ Shader "DCL/Scene_TexArray"
             #pragma multi_compile_fragment _ LOD_FADE_CROSSFADE
             #pragma multi_compile_fog
             //#pragma multi_compile_fragment _ DEBUG_DISPLAY
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
 
             //--------------------------------------
             // GPU Instancing
             #pragma multi_compile_instancing
             #pragma instancing_options renderinglayer
-            #pragma multi_compile _ DOTS_INSTANCING_ON
+            //#pragma multi_compile _ DOTS_INSTANCING_ON
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
 
             #include "Scene_Input_TexArray.hlsl"
@@ -196,7 +198,7 @@ Shader "DCL/Scene_TexArray"
             //--------------------------------------
             // GPU Instancing
             #pragma multi_compile_instancing
-            //#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
 
             // -------------------------------------
             // Universal Pipeline keywords
@@ -250,7 +252,7 @@ Shader "DCL/Scene_TexArray"
             //--------------------------------------
             // GPU Instancing
             #pragma multi_compile_instancing
-            //#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
 
             // -------------------------------------
             // Includes
@@ -301,7 +303,7 @@ Shader "DCL/Scene_TexArray"
             //--------------------------------------
             // GPU Instancing
             #pragma multi_compile_instancing
-            //#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
 
             // -------------------------------------
             // Includes


### PR DESCRIPTION
Allows the rebuild of `Scene_Tex.shader` to fix the[ visual glitch in Mac](https://github.com/decentraland/unity-explorer/issues/4046)