### PR TITLE
fix: gamma correction

### DIFF
--- a/Runtime/GLTFastWrappers/DecentralandMaterialGenerator.cs
+++ b/Runtime/GLTFastWrappers/DecentralandMaterialGenerator.cs
@@ -45,7 +45,7 @@ namespace DCL.GLTFast.Wrappers
             {
                 var specGloss = gltfMaterial.extensions.KHR_materials_pbrSpecularGlossiness;
 
-                SetColor(specGloss.DiffuseColor);
+                SetColor(specGloss.DiffuseColor.gamma);
                 SetSpecularColor(specGloss.SpecularColor);
                 SetGlossiness(specGloss.glossinessFactor);
                 SetBaseMapTexture(specGloss.diffuseTexture, gltf);
@@ -60,7 +60,7 @@ namespace DCL.GLTFast.Wrappers
 
                 if (roughness != null)
                 {
-                    SetColor(roughness.BaseColor);
+                    SetColor(roughness.BaseColor.gamma);
                     SetBaseMapTexture(roughness.baseColorTexture, gltf);
                     SetMetallic(roughness.metallicFactor);
                     SetMetallicRoughnessTexture(gltf, roughness.metallicRoughnessTexture, roughness.roughnessFactor);


### PR DESCRIPTION
This applies the same gamma correction that is done in the GLTFast package [here](https://github.com/decentraland/unity-gltf/blob/c6a7da496f4b0d61ae70487c4ddf4c7e68c64d36/Runtime/Scripts/Material/ShaderGraphMaterialGenerator.cs#L232) for our custom materials