### PR TITLE
fix: remove asset bundle name

### DIFF
--- a/Runtime/Shaders/Scene/SceneRendering/SceneVariants.shadervariants.meta
+++ b/Runtime/Shaders/Scene/SceneRendering/SceneVariants.shadervariants.meta
@@ -4,5 +4,5 @@ NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0
   userData: 
-  assetBundleName: scene_ignore_windows
+  assetBundleName:
   assetBundleVariant: 


### PR DESCRIPTION
Removes a wrongly set asset bundle name to stop the building of the shader in the asset-bundle-converter project