### PR TITLE
fix: rename wearables assembly definition

### DIFF
--- a/Runtime/Wearables.meta
+++ b/Runtime/Wearables.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: 1ff314b2f9bd4feba248864e44d07786
+guid: 35bfc4089eacf38498fa41a3e4454820
 timeCreated: 1758099512

--- a/Runtime/Wearables/Runtime.Wearables.asmdef
+++ b/Runtime/Wearables/Runtime.Wearables.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "Runtime.Wearables"
+}

--- a/Runtime/Wearables/Runtime.Wearables.asmdef.meta
+++ b/Runtime/Wearables/Runtime.Wearables.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 04dd32f2ac6a35442855e081f9f5db7a
+guid: 6da682aafc9e2724594f4e4bf9cc2550
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 

--- a/Runtime/Wearables/WearableCategories.cs.meta
+++ b/Runtime/Wearables/WearableCategories.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 6ed9d06b16d66744a9703bfce7c8c5fb
+guid: 931dd373f007ceb42891c0d52e5edf7e

--- a/Runtime/Wearables/WearableUtils.cs.meta
+++ b/Runtime/Wearables/WearableUtils.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 270073382bc66834bb730c4fae6fd3d8
+guid: 55373a361767e7342b222714eb2e4357

--- a/Runtime/Wearables/Wearables.asmdef
+++ b/Runtime/Wearables/Wearables.asmdef
@@ -1,3 +1,0 @@
-{
-	"name": "Wearables"
-}


### PR DESCRIPTION
Updated Runtime.Wearables.asmdef to prevent conflicts with explorer's assembly definitions