### PR TITLE
fix: added missing categories to colorpicker set

### DIFF
--- a/Runtime/Wearables/WearableCategories.cs
+++ b/Runtime/Wearables/WearableCategories.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Runtime.Wearables
 {
@@ -63,7 +63,9 @@ namespace Runtime.Wearables
         {
             Categories.EYES,
             Categories.HAIR,
-            Categories.BODY_SHAPE
+            Categories.BODY_SHAPE,
+            Categories.EYEBROWS,
+            Categories.FACIAL_HAIR
         };
 
         public static readonly Dictionary<string, string> READABLE_CATEGORIES = new Dictionary<string, string>()


### PR DESCRIPTION
This PR adds 2 missing categories that should show the color picker in the backpack.

PR needed for explorer PR: https://github.com/decentraland/unity-explorer/pull/5941