### PR TITLE
Add PR merge alignment reminder (vanilla)

### DIFF
--- a/.github/workflows/pr-merge-reminder.yml
+++ b/.github/workflows/pr-merge-reminder.yml
@@ -1,0 +1,24 @@
+name: PR Merge Alignment Reminder
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-reminder-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add merge alignment reminder
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            -d '{
+              "body": "## 🔗 Merge Alignment Reminder\n\nIf this PR targets `main`, please make sure the corresponding changes in **[unity-explorer](https://github.com/decentraland/unity-explorer/)** are also ready to merge.\n\nBoth repos should be merged in coordination to avoid breaking changes. **Do not merge one without the other being ready.**"
+            }'


### PR DESCRIPTION
## Summary
- Same as #85 but using plain `curl` instead of `actions/github-script`
- No third-party action dependencies — just a direct REST API call with `GITHUB_TOKEN`

## Test plan
- [x] Verify the workflow runs on this PR being opened and posts the reminder comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)