### PR TITLE
chore: use reusable pr-comment-reminder action

### DIFF
--- a/.github/workflows/pr-merge-reminder.yml
+++ b/.github/workflows/pr-merge-reminder.yml
@@ -5,20 +5,12 @@ on:
     types: [opened]
 
 jobs:
-  add-reminder-comment:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add merge alignment reminder
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          curl -s -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
-            -d '{
-              "body": "## 🔗 Merge Alignment Reminder\n\nIf this PR targets `main`, please make sure the corresponding changes in **[unity-explorer](https://github.com/decentraland/unity-explorer/)** are also ready to merge.\n\nBoth repos should be merged in coordination to avoid breaking changes. **Do not merge one without the other being ready.**"
-            }'
+  reminder:
+    uses: decentraland/actions/.github/workflows/pr-comment-reminder.yml@main
+    with:
+      message: |
+        ## 🔗 Merge Alignment Reminder
+
+        If this PR targets `main`, please make sure the corresponding changes in **[unity-explorer](https://github.com/decentraland/unity-explorer/)** are also ready to merge.
+
+        Both repos should be merged in coordination to avoid breaking changes. **Do not merge one without the other being ready.**

--- a/.github/workflows/pr-merge-reminder.yml
+++ b/.github/workflows/pr-merge-reminder.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   reminder:
-    uses: decentraland/actions/.github/workflows/pr-comment-reminder.yml@main
+    uses: decentraland/actions/.github/workflows/pr-comment-reminder.yml@fix/pr-comment-reminder
     with:
       message: |
         ## 🔗 Merge Alignment Reminder


### PR DESCRIPTION
## Summary
- Replaces the inline curl-based PR comment with the reusable `decentraland/actions/.github/workflows/pr-comment-reminder.yml` workflow
- Same reminder message, less boilerplate
- Ref: https://github.com/decentraland/actions/pull/15

## Test plan
- [ ] Open a test PR and verify the merge alignment reminder comment is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)